### PR TITLE
gh-89891: Refer SharedMemory implementation as POSIX

### DIFF
--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -23,7 +23,7 @@ processes, a :class:`~multiprocessing.managers.BaseManager` subclass,
 :class:`SharedMemoryManager`, is also provided in the
 ``multiprocessing.managers`` module.
 
-In this module, shared memory refers to "System V style" shared memory blocks
+In this module, shared memory refers to "POSIX style" shared memory blocks
 (though is not necessarily implemented explicitly as such) and does not refer
 to "distributed shared memory".  This style of shared memory permits distinct
 processes to potentially read and write to a common (or shared) region of


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--31.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->