### PR TITLE
gh-100554: Fix formatting of type.rst modifications

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -507,8 +507,7 @@ The following functions and structs are used to create
       The following internal fields cannot be set at all when creating a heap
       type:
 
-      * Internal fields:
-        :c:member:`~PyTypeObject.tp_dict`,
+      * :c:member:`~PyTypeObject.tp_dict`,
         :c:member:`~PyTypeObject.tp_mro`,
         :c:member:`~PyTypeObject.tp_cache`,
         :c:member:`~PyTypeObject.tp_subclasses`, and
@@ -528,11 +527,11 @@ The following functions and structs are used to create
         :c:member:`~PyBufferProcs.bf_releasebuffer` are now available
         under the :ref:`limited API <limited-c-api>`.
 
-      .. versionchanged:: 3.14
+     .. versionchanged:: 3.14
 
-         The field :c:member:`~PyTypeObject.tp_vectorcall` can now set
-         using ``Py_tp_vectorcall``.  See the field's documentation
-         for details.
+        The field :c:member:`~PyTypeObject.tp_vectorcall` can now set
+        using ``Py_tp_vectorcall``.  See the field's documentation
+        for details.
 
    .. c:member:: void *pfunc
 


### PR DESCRIPTION
PR gh-123332 has two minor formatting issues noticeable in [its documentation preview](https://cpython-previews--123332.org.readthedocs.build/en/123332/c-api/type.html#c.PyType_Slot.slot) only:

> ![](https://github.com/user-attachments/assets/d4d78258-7edb-4bb1-9473-da887547cce6)

> ![](https://github.com/user-attachments/assets/0d043cec-5331-4719-9556-cc8f7bb5b8cc)


This PR adresses them.

/cc @wjakob as an author of the referred PR.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--38.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->